### PR TITLE
Disable manual password change when LDAP is activated

### DIFF
--- a/LdapAuthenticationConnector.setup.php
+++ b/LdapAuthenticationConnector.setup.php
@@ -8,6 +8,10 @@ require_once( __DIR__."/LdapAuthenticationConnector.hooks.php" );
 
 $wgMessagesDirs['LdapAuthenticationConnector'] = __DIR__ . '/i18n';
 
+$bsgPermissionConfig[ 'usermanager-editpassword' ] = [
+	'roles' => []
+];
+
 $bsgLDAPAutoAuthChangeUser = false;
 
 function BSAutoAuthSetup( $domain ) {


### PR DESCRIPTION
I am not sure this is the way to go, i am not at all familiar with this
extension and i couldnt find any other way to
influence permissions if LDAP is activated

ERM: #5652